### PR TITLE
UPDATE vim-coloresque AUTHOR USER NAME

### DIFF
--- a/vim_template/langs/html/html.bundle
+++ b/vim_template/langs/html/html.bundle
@@ -1,5 +1,5 @@
 "" HTML Bundle
 Plug 'hail2u/vim-css3-syntax'
-Plug 'gorodinskiy/vim-coloresque'
+Plug 'gko/vim-coloresque'
 Plug 'tpope/vim-haml'
 Plug 'mattn/emmet-vim'


### PR DESCRIPTION
The Github user name for the author of vim-coloresque has changed. This causes issues when trying to run `PlugInstall`, giving the following error:
```x vim-coloresque:
    Invalid URI: https://github.com/gko/vim-coloresque.git
    Expected:    https://github.com/gorodinskiy/vim-coloresque.git
    PlugClean required.
```
This PR fix that by changing the user name from `gorodinskiy` to `gko`.